### PR TITLE
OSOE-1265: Update dependencies: axios 1.14.0 → 1.15.0, follow-redirects 1.15.11 → 1.16.0; fix MA0193 warning

### DIFF
--- a/Lombiq.EInvoiceValidator.Benchmark/Helpers/ValidationBenchmarkHelpers.cs
+++ b/Lombiq.EInvoiceValidator.Benchmark/Helpers/ValidationBenchmarkHelpers.cs
@@ -157,5 +157,5 @@ public static class ValidationBenchmarkHelpers
         };
 
     private static string ToAverageString(IEnumerable<long> numbers) =>
-        Math.Round(numbers.Average(), 3).ToTechnicalString()!;
+        Math.Round(numbers.Average(), 3, MidpointRounding.AwayFromZero).ToTechnicalString()!;
 }

--- a/Lombiq.EInvoiceValidator/libman.json
+++ b/Lombiq.EInvoiceValidator/libman.json
@@ -7,7 +7,7 @@
       "library": "asynckit@0.5.0"
     },
     {
-      "library": "axios@1.14.0"
+      "library": "axios@1.15.0"
     },
     {
       "library": "call-bind-apply-helpers@1.0.2"
@@ -34,7 +34,7 @@
       "library": "es-set-tostringtag@2.1.0"
     },
     {
-      "library": "follow-redirects@1.15.11"
+      "library": "follow-redirects@1.16.0"
     },
     {
       "library": "form-data@4.0.5"


### PR DESCRIPTION
[OSOE-1265](https://lombiq.atlassian.net/browse/OSOE-1265)
Integrates Renovate updates and fixes an MA0193 analyzer warning introduced by Meziantou.Analyzer 3.0.54:
- axios 1.14.0 → 1.15.0
- follow-redirects 1.15.11 → 1.16.0
- Fix MA0193: add MidpointRounding.AwayFromZero to Math.Round call in ValidationBenchmarkHelpers

[OSOE-1265]: https://lombiq.atlassian.net/browse/OSOE-1265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ