### PR TITLE
OSOE-1282: Add missing https-proxy-agent dependencies required by axios@1.16.1

### DIFF
--- a/Lombiq.EInvoiceValidator/libman.json
+++ b/Lombiq.EInvoiceValidator/libman.json
@@ -4,6 +4,9 @@
   "defaultDestination": "node_modules/[Name]",
   "libraries": [
     {
+      "library": "agent-base@6.0.2"
+    },
+    {
       "library": "asynckit@0.5.0"
     },
     {
@@ -14,6 +17,9 @@
     },
     {
       "library": "combined-stream@1.0.8"
+    },
+    {
+      "library": "debug@4.4.3"
     },
     {
       "library": "delayed-stream@1.0.0"
@@ -61,6 +67,9 @@
       "library": "hasown@2.0.3"
     },
     {
+      "library": "https-proxy-agent@5.0.1"
+    },
+    {
       "library": "math-intrinsics@1.1.0"
     },
     {
@@ -68,6 +77,9 @@
     },
     {
       "library": "mime-types@3.0.2"
+    },
+    {
+      "library": "ms@2.1.3"
     },
     {
       "library": "proxy-from-env@2.1.0"

--- a/Lombiq.EInvoiceValidator/libman.json
+++ b/Lombiq.EInvoiceValidator/libman.json
@@ -7,7 +7,7 @@
       "library": "asynckit@0.5.0"
     },
     {
-      "library": "axios@1.16.0"
+      "library": "axios@1.16.1"
     },
     {
       "library": "call-bind-apply-helpers@1.0.2"
@@ -28,7 +28,7 @@
       "library": "es-errors@1.3.0"
     },
     {
-      "library": "es-object-atoms@1.1.1"
+      "library": "es-object-atoms@1.1.2"
     },
     {
       "library": "es-set-tostringtag@2.1.0"


### PR DESCRIPTION
[OSOE-1282](https://lombiq.atlassian.net/browse/OSOE-1282)
Adds the missing `https-proxy-agent` (and its transitive dependencies `agent-base`, `debug`, `ms`) to `libman.json`. These were newly required by the `axios@1.16.0 to 1.16.1` update picked up by Renovate but were not added automatically. Fixes a test failure: `Cannot find module 'https-proxy-agent'` in `ValidatorTests`.

[OSOE-1282]: https://lombiq.atlassian.net/browse/OSOE-1282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ