### PR TITLE
OSOE-1283: Update dependencies: agent-base 6.0.2 -> 9.0.0, https-proxy-agent 5.0.1 -> 9.0.0, hasown 2.0.3 -> 2.0.4

### DIFF
--- a/Lombiq.EInvoiceValidator/libman.json
+++ b/Lombiq.EInvoiceValidator/libman.json
@@ -4,7 +4,7 @@
   "defaultDestination": "node_modules/[Name]",
   "libraries": [
     {
-      "library": "agent-base@6.0.2"
+      "library": "agent-base@9.0.0"
     },
     {
       "library": "asynckit@0.5.0"

--- a/Lombiq.EInvoiceValidator/libman.json
+++ b/Lombiq.EInvoiceValidator/libman.json
@@ -64,7 +64,7 @@
       "library": "has-tostringtag@1.0.2"
     },
     {
-      "library": "hasown@2.0.3"
+      "library": "hasown@2.0.4"
     },
     {
       "library": "https-proxy-agent@5.0.1"

--- a/Lombiq.EInvoiceValidator/libman.json
+++ b/Lombiq.EInvoiceValidator/libman.json
@@ -67,7 +67,7 @@
       "library": "hasown@2.0.3"
     },
     {
-      "library": "https-proxy-agent@5.0.1"
+      "library": "https-proxy-agent@9.0.0"
     },
     {
       "library": "math-intrinsics@1.1.0"


### PR DESCRIPTION
Integrates Renovate dependency updates. Relates to [OSOE-1283](https://lombiq.atlassian.net/browse/OSOE-1283).

[OSOE-1283]: https://lombiq.atlassian.net/browse/OSOE-1283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ